### PR TITLE
Fix P1-046: chart gap, mobile nav brand, nav spacing, lateral scroll

### DIFF
--- a/src/chart/chart.ts
+++ b/src/chart/chart.ts
@@ -129,7 +129,7 @@ export function createTemperatureChart(
         padding: {
           left: 0,
           right: 20,
-          top: 15,
+          top: 5,
           bottom: 15
         }
       },

--- a/src/share.ts
+++ b/src/share.ts
@@ -242,10 +242,12 @@ function hideAppChrome(): void {
     });
   }
 
-  // Rewrite the site title link to the root so it loads the splash/landing
-  // page rather than appending #/today to /s/:id.
+  // Rewrite the site title link and sidebar brand to the root so they load
+  // the splash/landing page rather than appending #/today to /s/:id.
   const siteLink = document.querySelector('header a') as HTMLAnchorElement | null;
   if (siteLink) siteLink.href = '/';
+  const sidebarBrand = document.querySelector('.sidebar-brand') as HTMLAnchorElement | null;
+  if (sidebarBrand) sidebarBrand.href = '/';
 
   // Hide any existing view sections (today, week, etc.)
   const viewOutlet = document.getElementById('viewOutlet');
@@ -498,7 +500,7 @@ async function renderShareChart(
       animation: { duration: 0 },
       normalized: true,
       layout: {
-        padding: { left: 0, right: 20, top: 15, bottom: 15 }
+        padding: { left: 0, right: 20, top: 5, bottom: 15 }
       },
       plugins: {
         legend: { display: false },

--- a/styles.scss
+++ b/styles.scss
@@ -38,6 +38,7 @@ html {
   min-height: 100vh;
   overflow-x: hidden; // Prevent horizontal page scroll
   overflow-y: auto; // Allow vertical scrolling
+  overscroll-behavior-x: none; // Prevent iOS lateral rubber-band scroll
   width: 100%;
   max-width: 100%; // Prevent overflow
   position: relative;
@@ -54,6 +55,8 @@ body {
   min-height: 100vh;
   padding-bottom: 3rem; // Extra bottom padding for mobile browser bar
   overflow-x: hidden; // Prevent horizontal page scroll
+  overscroll-behavior-x: none; // Prevent iOS lateral rubber-band scroll
+  touch-action: pan-y; // Disable horizontal touch-panning at document level
   position: relative; // Establish positioning context
   width: 100%;
   max-width: 100%; // Use percentage instead of 100vw to avoid scrollbar width issues
@@ -388,6 +391,10 @@ a {
 }
 
 #sidebar ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+
+.sidebar-brand {
+  display: none; // Hidden on desktop — header already shows logo and title
+}
 .menu-selected-bg {
   background: rgba($colour-loading-text, 0.1);
 }
@@ -428,12 +435,13 @@ a {
   padding-bottom: 4rem; // Extra bottom padding for mobile browser bar
   position: relative;
   overflow-y: auto;
-  overflow-x: hidden; // Prevent horizontal scrolling
+  overflow-x: clip; // Clip horizontal overflow without creating a new scroll container
+  overscroll-behavior-x: none; // Prevent iOS lateral rubber-band on this scroll container
   max-width: 100%; // Use percentage instead of 100vw to avoid scrollbar width issues
   box-sizing: border-box; // Include padding in width calculation
   -webkit-overflow-scrolling: touch; // Smooth scrolling on iOS
   width: 100%;
-  
+
   // On desktop, allow overflow upward for negative margin
   @media (min-width: 901px) {
     overflow-y: auto; // Allow vertical scrolling
@@ -518,7 +526,6 @@ body.privacy-page {
     .image-attribution-text {
       flex: 1;
       min-width: 0; // Allow text to wrap properly
-      max-width: 400px;
       font-size: 90%;
       @media (min-width: 901px) {
         margin-top: 1rem;
@@ -784,7 +791,7 @@ h2, .date-heading {
     }
     
     a {
-      padding: 12px 10px; // Increased padding for better touch targets
+      padding: 8px 10px;
       font-size: 1rem; // Ensure consistent font size
       line-height: 1.4; // Better line height for larger text
       white-space: nowrap; // Prevent text wrapping
@@ -792,6 +799,35 @@ h2, .date-heading {
       text-overflow: ellipsis; // Show ellipsis if text is too long
     }
   }
+
+  .sidebar-brand {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 80px; // Occupies the sidebar's padding-top space
+    padding: 0 16px;
+    box-sizing: border-box;
+    text-decoration: none;
+    color: $colour-text;
+    border-bottom: 1px solid rgba($colour-loading-text, 0.15);
+
+    img {
+      flex-shrink: 0;
+    }
+
+    span {
+      font-size: 1.1rem;
+      font-weight: bold;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
   #sidebar.open { transform: translateX(0); }
   body.menu-open { 
     overflow: hidden;

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -1,4 +1,9 @@
       <nav id="sidebar" aria-label="Primary">
+        <a class="sidebar-brand" href="{{HOME_LINK}}">
+          <img src="/assets/logo.svg" alt="TempHist logo" width="36" height="36"
+               onerror="this.onerror=null; this.src='/assets/logo.png'" />
+          <span>TempHist</span>
+        </a>
         <ul>
           <li {{APP_NAV_HIDDEN}}><a href="{{TODAY_LINK}}" data-route="/today">Today</a></li>
           <li {{APP_NAV_HIDDEN}}><a href="{{WEEK_LINK}}" data-route="/week">Past week</a></li>


### PR DESCRIPTION
Closes #17

## Summary

- **Chart gap** — Reduce Chart.js `layout.padding.top` from 15→5 in `chart.ts` and `share.ts`, closing the excess whitespace between the summary text and the chart bars while preserving room for the average line annotation.
- **Share page mobile nav** — Add a `.sidebar-brand` block (logo + "TempHist" title) inside `#sidebar`. Visible only on mobile (desktop hides it since the header already shows the brand). Links to `/` on share pages (href rewritten at runtime alongside the existing header link fix), and to `#/today` in the SPA.
- **Nav spacing** — Mobile nav link padding equalised to `8px 10px` to match desktop (was `12px 10px`).
- **Lateral scroll shift** — `overscroll-behavior-x: none` added to `html` and `body`; `touch-action: pan-y` added to `body`; `#viewOutlet` switched to `overflow-x: clip` (avoids creating an unwanted scroll container) with `overscroll-behavior-x: none`; removed `max-width: 400px` from `.image-attribution-text` which was redundant and potentially causing overflow in the About page attribution list.

## Test plan

- [ ] Load a data page (Today/week/month/year) — gap above the chart bars should be noticeably reduced; average line annotation should still have a small amount of space above it
- [ ] Load a share page (`/s/:id`) on a mobile viewport (< 900px), open the burger menu — TempHist logo and title should appear at the top of the sidebar and link to `/`
- [ ] On a desktop viewport, open the sidebar — `.sidebar-brand` should not be visible (header already shows it)
- [ ] At the 900px breakpoint, compare mobile and desktop nav item spacing — should look consistent
- [ ] On an iOS device or Chrome DevTools with touch emulation, scroll vertically on a share page and the About page — page should not shift left/right

🤖 Generated with [Claude Code](https://claude.com/claude-code)